### PR TITLE
Add help button for 'Send existing questions as context' option

### DIFF
--- a/classes/form/story_form.php
+++ b/classes/form/story_form.php
@@ -178,6 +178,7 @@ class story_form extends \moodleform {
 
         $mform->addElement('checkbox', 'sendexistingquestionsascontext',
                 get_string('sendexistingquestionsascontext', 'qbank_questiongen'));
+        $mform->addHelpButton('sendexistingquestionsascontext', 'sendexistingquestionsascontext', 'qbank_questiongen');
         $mform->setDefault('sendexistingquestionsascontext', 1);
         $mform->setType('sendexistingquestionsascontext', PARAM_BOOL);
 


### PR DESCRIPTION
Since the "Send existing questions as context" feature is not self-explanatory, I thought a help icon would be useful. The help string was already there. =)